### PR TITLE
Feat/personal schedule page navigation

### DIFF
--- a/src/components/Header/GroupHeader/GroupHeader.jsx
+++ b/src/components/Header/GroupHeader/GroupHeader.jsx
@@ -1,42 +1,26 @@
 import React from "react";
-import { useDispatch } from "react-redux";
 import { NavLink, useLocation } from "react-router-dom";
 
-import { openModal } from "@/features/ui/ui-slice.js";
-
-import { Wrapper, MenuWrapper, GroupCreateBtn } from "./GroupHeader.styles";
+import { GroupHeaderNav, GroupHeaderUl } from "./GroupHeader.styles";
 
 const GroupHeader = () => {
-	const dispatch = useDispatch();
 	const location = useLocation();
-
-	const getPageTitle = () => {
-		switch (location.pathname) {
-			case "/":
-				return "개인 일정";
-			default:
-				return "공유 일정";
-		}
-	};
-
+	const isPersonal = location.pathname === "/";
 	return (
-		<Wrapper>
-			<MenuWrapper>
-				<h1>{getPageTitle()}</h1>
-				<ul>
-					<NavLink to="/share">홈</NavLink>
-					<NavLink to="/">개인 일정</NavLink>
-				</ul>
-			</MenuWrapper>
-			<GroupCreateBtn>
-				<button
-					type="button"
-					onClick={() => dispatch(openModal({ type: "SHARE_PAGE_CREATE" }))}
-				>
-					공유 페이지 생성
-				</button>
-			</GroupCreateBtn>
-		</Wrapper>
+		<GroupHeaderNav>
+			<GroupHeaderUl>
+				<li>
+					<NavLink to="/" className={`${isPersonal ? "activated" : ""}`}>
+						개인 일정
+					</NavLink>
+				</li>
+				<li>
+					<NavLink to="/share" className={`${!isPersonal ? "activated" : ""}`}>
+						그룹 일정
+					</NavLink>
+				</li>
+			</GroupHeaderUl>
+		</GroupHeaderNav>
 	);
 };
 

--- a/src/components/Header/GroupHeader/GroupHeader.jsx
+++ b/src/components/Header/GroupHeader/GroupHeader.jsx
@@ -1,21 +1,25 @@
 import React from "react";
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 import { GroupHeaderNav, GroupHeaderUl } from "./GroupHeader.styles";
 
 const GroupHeader = () => {
-	const location = useLocation();
-	const isPersonal = location.pathname === "/";
 	return (
 		<GroupHeaderNav>
 			<GroupHeaderUl>
 				<li>
-					<NavLink to="/" className={`${isPersonal ? "activated" : ""}`}>
+					<NavLink
+						to="/"
+						className={({ isActive }) => (isActive ? "activated" : "")}
+					>
 						개인 일정
 					</NavLink>
 				</li>
 				<li>
-					<NavLink to="/share" className={`${!isPersonal ? "activated" : ""}`}>
+					<NavLink
+						to="/share"
+						className={({ isActive }) => (isActive ? "activated" : "")}
+					>
 						그룹 일정
 					</NavLink>
 				</li>

--- a/src/components/Header/GroupHeader/GroupHeader.styles.js
+++ b/src/components/Header/GroupHeader/GroupHeader.styles.js
@@ -1,64 +1,20 @@
 import styled from "styled-components";
 
-export const Wrapper = styled.div`
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 2rem 2rem 2rem 6rem;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-	font-family: "Inter", sans-serif;
+import lightTheme from "@/styles/theme";
+
+export const GroupHeaderNav = styled.nav`
+	margin-left: 196px;
 `;
 
-export const MenuWrapper = styled.div`
+export const GroupHeaderUl = styled.ul`
+	width: 227px;
 	display: flex;
-	align-items: center;
-
-	h1 {
-		min-width: 200px;
-		font-weight: 700;
-		font-size: 1.5rem;
-		color: #000000;
-		margin-right: 8rem;
-	}
-
-	ul {
-		display: flex;
-		gap: 4rem;
-		padding: 0;
-		margin: 0 0 4px 0;
-
-		a {
-			color: gray;
-			font-size: 1.15rem;
-			font-weight: 500;
-			text-transform: uppercase;
-			text-decoration: none;
-			transition: all 0.3s;
-			border-bottom: 2px solid transparent;
-
-			&:hover {
-				border-color: #000000;
-			}
-
-			&.active {
-				color: #000000;
-				font-weight: 700;
-			}
-		}
-	}
-`;
-
-export const GroupCreateBtn = styled.div`
-	button {
-		font-size: 1.15rem;
-		font-weight: 700;
-		color: #ffffff;
-		background-color: #313131;
-		border-radius: 50px;
-		padding: 0.8rem 1.5rem;
-		transition: all 0.3s;
-		&:hover {
-			color: lightgray;
+	justify-content: space-around;
+	& > li > a {
+		color: ${lightTheme.colors.text_01};
+		&.activated {
+			color: ${lightTheme.colors.primary};
+			font-weight: ${lightTheme.typography.weight.semibold};
 		}
 	}
 `;

--- a/src/components/Header/GroupHeader/GroupHeader.styles.js
+++ b/src/components/Header/GroupHeader/GroupHeader.styles.js
@@ -1,7 +1,5 @@
 import styled from "styled-components";
 
-import lightTheme from "@/styles/theme";
-
 export const GroupHeaderNav = styled.nav`
 	margin-left: 196px;
 `;
@@ -11,10 +9,16 @@ export const GroupHeaderUl = styled.ul`
 	display: flex;
 	justify-content: space-around;
 	& > li > a {
-		color: ${lightTheme.colors.text_01};
+		color: ${({ theme: { colors } }) => colors.text_01};
 		&.activated {
-			color: ${lightTheme.colors.primary};
-			font-weight: ${lightTheme.typography.weight.semibold};
+			color: ${({ theme: { colors } }) => colors.primary};
+			font-weight: ${({
+				theme: {
+					typography: {
+						weight: { semibold },
+					},
+				},
+			}) => semibold};
 		}
 	}
 `;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -1,61 +1,143 @@
-import { createGlobalStyle } from "styled-components";
+import { createGlobalStyle, css } from "styled-components";
 
-const GlobalStyles = createGlobalStyle`
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
-	display: block;
-}
+const GlobalStyles = createGlobalStyle`${css`
+	html,
+	body,
+	div,
+	span,
+	applet,
+	object,
+	iframe,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	p,
+	blockquote,
+	pre,
+	a,
+	abbr,
+	acronym,
+	address,
+	big,
+	cite,
+	code,
+	del,
+	dfn,
+	em,
+	img,
+	ins,
+	kbd,
+	q,
+	s,
+	samp,
+	small,
+	strike,
+	strong,
+	sub,
+	sup,
+	tt,
+	var,
+	b,
+	u,
+	i,
+	center,
+	dl,
+	dt,
+	dd,
+	ol,
+	ul,
+	li,
+	fieldset,
+	form,
+	label,
+	legend,
+	table,
+	caption,
+	tbody,
+	tfoot,
+	thead,
+	tr,
+	th,
+	td,
+	article,
+	aside,
+	canvas,
+	details,
+	embed,
+	figure,
+	figcaption,
+	footer,
+	header,
+	hgroup,
+	menu,
+	nav,
+	output,
+	ruby,
+	section,
+	summary,
+	time,
+	mark,
+	audio,
+	video {
+		margin: 0;
+		padding: 0;
+		border: 0;
+		font-size: 100%;
+		font: inherit;
+		vertical-align: baseline;
+	}
+	/* HTML5 display-role reset for older browsers */
+	article,
+	aside,
+	details,
+	figcaption,
+	figure,
+	footer,
+	header,
+	hgroup,
+	menu,
+	nav,
+	section {
+		display: block;
+	}
 
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
+	ol,
+	ul {
+		list-style: none;
+	}
+	blockquote,
+	q {
+		quotes: none;
+	}
 
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
+	blockquote:before,
+	blockquote:after,
+	q:before,
+	q:after {
+		content: "";
+		content: none;
+	}
 
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
+	table {
+		border-collapse: collapse;
+		border-spacing: 0;
+	}
 
-body {
-	margin: 0 auto;
-	padding: 0;
-	box-sizing: border-box;
-	line-height: 1;
-	max-width: 1440px;
-}
-a {
-	text-decoration: none;
-	color: inherit;
-}
+	body {
+		margin: 0 auto;
+		padding: 0;
+		box-sizing: border-box;
+		line-height: 1;
+		max-width: 1440px;
+	}
+	a {
+		text-decoration: none;
+		color: inherit;
+	}
+`}
 `;
 
 export default GlobalStyles;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -55,11 +55,6 @@ body {
 a {
 	text-decoration: none;
 }
-
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
 `;
 
 export default GlobalStyles;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -14,6 +14,8 @@ article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup, 
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
+	margin: 0;
+	padding: 0;
 	border: 0;
 	font-size: 100%;
 	font: inherit;
@@ -24,6 +26,25 @@ article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
+
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+
 body {
 	margin: 0 auto;
 	padding: 0;
@@ -34,17 +55,7 @@ body {
 a {
 	text-decoration: none;
 }
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
+
 table {
 	border-collapse: collapse;
 	border-spacing: 0;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -54,6 +54,7 @@ body {
 }
 a {
 	text-decoration: none;
+	color: inherit;
 }
 `;
 

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -12,6 +12,7 @@ const lightTheme = {
 		bg_01: "#FCFDFF",
 		bg_02: "#F5F6F7",
 		bg_03: "#F4F6FC",
+		text_01: "#121127",
 		error: "#BA1A1A",
 	},
 	spacing: {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -33,6 +33,7 @@ const lightTheme = {
 		},
 		weight: {
 			regular: "400",
+			semibold: "600",
 			bold: "700",
 			extrabold: "800",
 			black: "900",


### PR DESCRIPTION
# 설명
개인 일정과 그룹 일정 nav를 구현하였습니다.
figma 디자인에 따라 필요없는 버튼과 레이아웃은 제거하고 진행하였습니다.
- `theme.js`에 빠져있는 값 `lightTheme.colors.text_01`와 `lightTheme.typography.weight.semibold` 값을 추가하였습니다.
- 기존 디자인에서 변경하기로 했듯이 **개인 일정**을 우선 배치했습니다.


# Demo
<img width="561" alt="스크린샷 2023-08-21 오후 2 14 30" src="https://github.com/Selody-project/Frontend/assets/78777345/97442b96-507c-4191-a953-db22dc0ae22f">