### PR TITLE
#118 feat: reset.css 적용 및 중복 속성 제거

### DIFF
--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -1,61 +1,143 @@
-import { createGlobalStyle } from "styled-components";
+import { createGlobalStyle, css } from "styled-components";
 
-const GlobalStyles = createGlobalStyle`
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
-	display: block;
-}
+const GlobalStyles = createGlobalStyle`${css`
+	html,
+	body,
+	div,
+	span,
+	applet,
+	object,
+	iframe,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	p,
+	blockquote,
+	pre,
+	a,
+	abbr,
+	acronym,
+	address,
+	big,
+	cite,
+	code,
+	del,
+	dfn,
+	em,
+	img,
+	ins,
+	kbd,
+	q,
+	s,
+	samp,
+	small,
+	strike,
+	strong,
+	sub,
+	sup,
+	tt,
+	var,
+	b,
+	u,
+	i,
+	center,
+	dl,
+	dt,
+	dd,
+	ol,
+	ul,
+	li,
+	fieldset,
+	form,
+	label,
+	legend,
+	table,
+	caption,
+	tbody,
+	tfoot,
+	thead,
+	tr,
+	th,
+	td,
+	article,
+	aside,
+	canvas,
+	details,
+	embed,
+	figure,
+	figcaption,
+	footer,
+	header,
+	hgroup,
+	menu,
+	nav,
+	output,
+	ruby,
+	section,
+	summary,
+	time,
+	mark,
+	audio,
+	video {
+		margin: 0;
+		padding: 0;
+		border: 0;
+		font-size: 100%;
+		font: inherit;
+		vertical-align: baseline;
+	}
+	/* HTML5 display-role reset for older browsers */
+	article,
+	aside,
+	details,
+	figcaption,
+	figure,
+	footer,
+	header,
+	hgroup,
+	menu,
+	nav,
+	section {
+		display: block;
+	}
 
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
+	ol,
+	ul {
+		list-style: none;
+	}
+	blockquote,
+	q {
+		quotes: none;
+	}
 
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
+	blockquote:before,
+	blockquote:after,
+	q:before,
+	q:after {
+		content: "";
+		content: none;
+	}
 
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
+	table {
+		border-collapse: collapse;
+		border-spacing: 0;
+	}
 
-body {
-	margin: 0 auto;
-	padding: 0;
-	box-sizing: border-box;
-	line-height: 1;
-	max-width: 1440px;
-}
-a {
-	text-decoration: none;
-	color: inherit;
-}
+	body {
+		margin: 0 auto;
+		padding: 0;
+		box-sizing: border-box;
+		line-height: 1;
+		max-width: 1440px;
+	}
+	a {
+		text-decoration: none;
+		color: inherit;
+	}
+`}
 `;
 
 export default GlobalStyles;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -55,11 +55,6 @@ body {
 a {
 	text-decoration: none;
 }
-
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
 `;
 
 export default GlobalStyles;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -14,6 +14,8 @@ article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup, 
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
+	margin: 0;
+	padding: 0;
 	border: 0;
 	font-size: 100%;
 	font: inherit;
@@ -24,6 +26,25 @@ article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
+
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+
 body {
 	margin: 0 auto;
 	padding: 0;
@@ -34,17 +55,7 @@ body {
 a {
 	text-decoration: none;
 }
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
+
 table {
 	border-collapse: collapse;
 	border-spacing: 0;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -54,6 +54,7 @@ body {
 }
 a {
 	text-decoration: none;
+	color: inherit;
 }
 `;
 


### PR DESCRIPTION
# 설명
- #118 
- reset.css로 css 초기화 진행하였으며, 기존 글로벌 스타일과의 중복을 제거하였습니다. 중복이 있거나 하는 잘못된 부분이 발견되면 리뷰 부탁드립니다.