### PR TITLE
185 front task 그룹 일정 조회 및 그룹별 유니크한 색 추가

### DIFF
--- a/__test__/pagesTest/PersonalSchedulePage.test.jsx
+++ b/__test__/pagesTest/PersonalSchedulePage.test.jsx
@@ -26,6 +26,9 @@ const getInitialScheduleState = ({ recurrence, isAllDay, isMine }) => {
 	}
 	return {
 		schedule: {
+			calendarSchedules: [],
+			currentGroupScheduleId: null,
+			scheduleProposals: [],
 			todaySchedules: [
 				{
 					id: 0,
@@ -37,7 +40,6 @@ const getInitialScheduleState = ({ recurrence, isAllDay, isMine }) => {
 					recurrence,
 				},
 			],
-			calendarSchedules: [],
 			schedulesForTheWeek: [],
 			overlappedScheduleInfo: {
 				title: "",
@@ -590,7 +592,7 @@ describe("ScheduleModal in PersonalSchedulePage", () => {
 			});
 
 			// open ScheduleModal as a create mode
-			userEvent.click(screen.getByRole("button", { name: "일정 추가" }));
+			await userEvent.click(screen.getByRole("button", { name: "일정 추가" }));
 
 			// action
 			const titleInput = screen.getByPlaceholderText("일정 제목");
@@ -603,7 +605,6 @@ describe("ScheduleModal in PersonalSchedulePage", () => {
 			userEvent.type(contentTextarea, CONTENT_TEXT);
 			userEvent.click(allDayCheckbox);
 			await userEvent.click(screen.getByRole("button", { name: "저장하기" }));
-
 			// assertion
 			expect(
 				await screen.findByRole("heading", {

--- a/src/components/Common/SchedulePage/CalendarContainer/CalendarContainer.jsx
+++ b/src/components/Common/SchedulePage/CalendarContainer/CalendarContainer.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import moment from "moment";
+import { useTheme } from "styled-components";
 
 import { getSchedulesSummary } from "@/features/schedule/schedule-service";
 import {
@@ -13,6 +14,7 @@ import {
 	convertByweekdayNumberToString,
 	getCurrentWeek,
 	getFirstDateOfWeek,
+	getGroupColor,
 } from "@/utils/calendarUtils";
 
 import { CalendarContainerDiv } from "./CalendarContainer.styles";
@@ -22,6 +24,7 @@ const CalendarContainer = ({ isPersonal }) => {
 	const dispatch = useDispatch();
 
 	const calendarRef = useRef(null);
+	const theme = useTheme();
 
 	const { calendarSchedules } = useSelector((state) => state.schedule);
 
@@ -39,12 +42,18 @@ const CalendarContainer = ({ isPersonal }) => {
 					},
 					duration:
 						new Date(schedule.endDateTime) - new Date(schedule.startDateTime),
+					color: schedule.isGroup
+						? getGroupColor(schedule.id)
+						: theme.colors.disabled_text,
 			  }
 			: {
 					id: schedule.id,
 					userId: schedule.userId,
 					start: new Date(schedule.startDateTime),
 					end: new Date(schedule.endDateTime),
+					color: schedule.isGroup
+						? getGroupColor(schedule.id)
+						: theme.colors.disabled_text,
 			  },
 	);
 

--- a/src/components/Common/SchedulePage/CalendarContainer/CalendarContainer.jsx
+++ b/src/components/Common/SchedulePage/CalendarContainer/CalendarContainer.jsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import moment from "moment";
 import { useTheme } from "styled-components";
 
-import { getSchedulesSummary } from "@/features/schedule/schedule-service";
 import {
 	setCurrentMonth,
 	setCurrentWeek,
@@ -20,7 +19,7 @@ import {
 import { CalendarContainerDiv } from "./CalendarContainer.styles";
 import CustomCalendar from "./CustomCalendar/CustomCalendar";
 
-const CalendarContainer = ({ isPersonal }) => {
+const CalendarContainer = () => {
 	const dispatch = useDispatch();
 
 	const calendarRef = useRef(null);
@@ -106,15 +105,6 @@ const CalendarContainer = ({ isPersonal }) => {
 		}
 		updateDateState(year, month, week);
 	};
-
-	useEffect(() => {
-		dispatch(
-			getSchedulesSummary({
-				isGroup: !isPersonal,
-				groupId: !isPersonal ? 1 : undefined,
-			}),
-		);
-	}, []);
 
 	return (
 		<CalendarContainerDiv>

--- a/src/components/Common/SchedulePage/CalendarContainer/CustomCalendar/CustomCalendar.jsx
+++ b/src/components/Common/SchedulePage/CalendarContainer/CustomCalendar/CustomCalendar.jsx
@@ -6,7 +6,6 @@ import interactionPlugin from "@fullcalendar/interaction";
 import FullCalendar from "@fullcalendar/react";
 import rrulePlugin from "@fullcalendar/rrule";
 import timeGridPlugin from "@fullcalendar/timegrid";
-import { useTheme } from "styled-components";
 
 import { VIEW_TYPE } from "@/constants/calendarConstants";
 import { getOverlappedSchedules } from "@/features/schedule/schedule-service";
@@ -111,8 +110,6 @@ const CustomCalendar = forwardRef(
 		const { currentYear, currentMonth, currentWeek, currentCalendarView } =
 			useSelector((state) => state.schedule);
 		const dispatch = useDispatch();
-
-		const theme = useTheme();
 
 		/** 리스트 뷰: 일정 박스를 클릭 시, 여기서 겹친 일정들 중에서 가장 작은 단위에 일정이 조회됩니다 */
 		const handleScheduleClick = (clickedInfo) => {
@@ -257,7 +254,6 @@ const CustomCalendar = forwardRef(
 					}}
 					slotLabelFormat={getTimeFormat}
 					slotDuration="1:00:00"
-					eventBackgroundColor={theme.colors.disabled_text}
 					displayEventTime={false}
 					eventDisplay="block"
 					eventBorderColor="transparent"

--- a/src/components/Common/SchedulePage/ScheduleItemList/ScheduleItem/ScheduleItem.jsx
+++ b/src/components/Common/SchedulePage/ScheduleItemList/ScheduleItem/ScheduleItem.jsx
@@ -15,7 +15,7 @@ import {
 	openScheduleEditModal,
 	openScheduleViewModal,
 } from "@/features/ui/ui-slice";
-import { checkIsAlldaySchedule } from "@/utils/calendarUtils";
+import { checkIsAlldaySchedule, getGroupColor } from "@/utils/calendarUtils";
 
 import {
 	CardDiv,
@@ -94,7 +94,7 @@ const ScheduleItem = ({
 			<ScheduleItemLi data-testid={`scheduleItem-${id}`}>
 				<CardDiv>
 					<ColoredCircleDiv
-						bgColor={isGroup ? colors.sunday : colors.disabled_text}
+						bgColor={isGroup ? getGroupColor(id) : colors.disabled_text}
 					/>
 					<ScheduleItemContentDiv>
 						<div>

--- a/src/components/Common/SchedulePage/ScheduleItemList/ScheduleItemList.jsx
+++ b/src/components/Common/SchedulePage/ScheduleItemList/ScheduleItemList.jsx
@@ -1,13 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import ScheduleItem from "@/components/Common/SchedulePage/ScheduleItemList/ScheduleItem/ScheduleItem";
+import { SCHEDULE_PAGE_TYPE } from "@/constants/calendarConstants";
 import { DottedCalendarIcon, ScheduleAddIcon } from "@/constants/iconConstants";
 import { UI_TYPE } from "@/constants/uiConstants";
-import {
-	getSchedulesForTheWeek,
-	getTodaySchedules,
-} from "@/features/schedule/schedule-service.js";
 import { resetOverlappedSchedules } from "@/features/schedule/schedule-slice";
 import { openScheduleCreateModal } from "@/features/ui/ui-slice";
 
@@ -24,7 +21,7 @@ import {
 	TodoTabButton,
 } from "./ScheduleItemList.styles";
 
-const ScheduleItemList = ({ isPersonal }) => {
+const ScheduleItemList = () => {
 	const dispatch = useDispatch();
 	const {
 		scheduleProposals,
@@ -34,8 +31,11 @@ const ScheduleItemList = ({ isPersonal }) => {
 			title: overlappedScheduleTitle,
 			schedules: overlappedSchedules,
 		},
+		currentPageType,
 	} = useSelector((state) => state.schedule);
 	const [currentTabIndex, setCurrentTabIndex] = useState(0);
+
+	const isPersonal = currentPageType === SCHEDULE_PAGE_TYPE.PERSONAL;
 
 	const isTodayTab =
 		(isPersonal && currentTabIndex === 0) ||
@@ -48,11 +48,6 @@ const ScheduleItemList = ({ isPersonal }) => {
 	const isProposalTab = !isPersonal && currentTabIndex === 0;
 
 	const isOverlappedSchedulesOn = overlappedSchedules.length > 0;
-
-	useEffect(() => {
-		dispatch(getTodaySchedules());
-		dispatch(getSchedulesForTheWeek());
-	}, []);
 
 	const handleMenuOpen = () => {
 		dispatch(

--- a/src/constants/calendarConstants.js
+++ b/src/constants/calendarConstants.js
@@ -4,7 +4,7 @@ export const VIEW_TYPE = {
 	DAY_GRID_MONTH: "dayGridMonth",
 };
 
-export const CALENDAR_USER_COLORS = [
+export const GROUP_SCHEDULE_COLORS = [
 	"#669900",
 	"#99cc33",
 	"#ccee66",

--- a/src/constants/calendarConstants.js
+++ b/src/constants/calendarConstants.js
@@ -4,6 +4,11 @@ export const VIEW_TYPE = {
 	DAY_GRID_MONTH: "dayGridMonth",
 };
 
+export const SCHEDULE_PAGE_TYPE = {
+	PERSONAL: "personal",
+	SHARED: "shared",
+};
+
 export const GROUP_SCHEDULE_COLORS = [
 	"#669900",
 	"#99cc33",

--- a/src/pages/PersonalSchedulePage.jsx
+++ b/src/pages/PersonalSchedulePage.jsx
@@ -5,9 +5,17 @@ import ScheduleModal from "@/components/Common/ScheduleModal/ScheduleModal";
 import CalendarContainer from "@/components/Common/SchedulePage/CalendarContainer/CalendarContainer";
 import ScheduleItemList from "@/components/Common/SchedulePage/ScheduleItemList/ScheduleItemList";
 import { LayoutMain } from "@/components/Common/SchedulePage/SchedulePageLayout.styles";
-import { VIEW_TYPE } from "@/constants/calendarConstants";
+import { SCHEDULE_PAGE_TYPE, VIEW_TYPE } from "@/constants/calendarConstants";
 import { UI_TYPE } from "@/constants/uiConstants";
-import { resetSchedule } from "@/features/schedule/schedule-slice";
+import {
+	getSchedulesForTheWeek,
+	getSchedulesSummary,
+	getTodaySchedules,
+} from "@/features/schedule/schedule-service";
+import {
+	changeSchedulePage,
+	resetSchedule,
+} from "@/features/schedule/schedule-slice";
 
 const PersonalSchedulePage = () => {
 	const dispatch = useDispatch();
@@ -17,6 +25,13 @@ const PersonalSchedulePage = () => {
 	);
 
 	useEffect(() => {
+		const getPersonalPageInfo = async () => {
+			await dispatch(changeSchedulePage(SCHEDULE_PAGE_TYPE.PERSONAL));
+			dispatch(getSchedulesSummary());
+			dispatch(getTodaySchedules());
+			dispatch(getSchedulesForTheWeek());
+		};
+		getPersonalPageInfo();
 		return () => {
 			dispatch(resetSchedule());
 		};
@@ -25,8 +40,8 @@ const PersonalSchedulePage = () => {
 	return (
 		<>
 			<LayoutMain isMonthly={currentCalendarView === VIEW_TYPE.DAY_GRID_MONTH}>
-				<CalendarContainer isPersonal={true} />
-				<ScheduleItemList isPersonal={true} />
+				<CalendarContainer />
+				<ScheduleItemList />
 			</LayoutMain>
 			{openedModal === UI_TYPE.PERSONAL_SCHEDULE && (
 				<ScheduleModal type={openedModal} />

--- a/src/pages/SharedSchedulePage.jsx
+++ b/src/pages/SharedSchedulePage.jsx
@@ -4,8 +4,18 @@ import { useDispatch, useSelector } from "react-redux";
 import CalendarContainer from "@/components/Common/SchedulePage/CalendarContainer/CalendarContainer";
 import ScheduleItemList from "@/components/Common/SchedulePage/ScheduleItemList/ScheduleItemList";
 import { LayoutMain } from "@/components/Common/SchedulePage/SchedulePageLayout.styles";
-import { VIEW_TYPE } from "@/constants/calendarConstants";
-import { resetSchedule } from "@/features/schedule/schedule-slice";
+import { SCHEDULE_PAGE_TYPE, VIEW_TYPE } from "@/constants/calendarConstants";
+import {
+	getGroupScheduleProposal,
+	getSchedulesForTheWeek,
+	getSchedulesSummary,
+	getTodaySchedules,
+} from "@/features/schedule/schedule-service";
+import {
+	changeSchedulePage,
+	resetSchedule,
+} from "@/features/schedule/schedule-slice";
+import { inqueryUserGroup } from "@/features/user/user-service";
 
 const SharedSchedulePage = () => {
 	const dispatch = useDispatch();
@@ -14,6 +24,15 @@ const SharedSchedulePage = () => {
 	);
 
 	useEffect(() => {
+		const getSharedSchedulePageInfo = async () => {
+			await dispatch(changeSchedulePage(SCHEDULE_PAGE_TYPE.SHARED));
+			await dispatch(inqueryUserGroup());
+			dispatch(getSchedulesSummary());
+			dispatch(getTodaySchedules());
+			dispatch(getSchedulesForTheWeek());
+			dispatch(getGroupScheduleProposal());
+		};
+		getSharedSchedulePageInfo();
 		return () => {
 			dispatch(resetSchedule());
 		};
@@ -21,8 +40,8 @@ const SharedSchedulePage = () => {
 
 	return (
 		<LayoutMain isMonthly={currentCalendarView === VIEW_TYPE.DAY_GRID_MONTH}>
-			<CalendarContainer isPersonal={false} />
-			<ScheduleItemList isPersonal={false} />
+			<CalendarContainer />
+			<ScheduleItemList />
 		</LayoutMain>
 	);
 };

--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -1,6 +1,7 @@
 import moment from "moment";
 
 import customFetch from "@/components/UI/BaseAxios";
+import { GROUP_SCHEDULE_COLORS } from "@/constants/calendarConstants";
 import convertToUTC from "@/utils/convertToUTC";
 
 // 리스트(주마다 보기)로 진행했을 떄 보여줄 첫 일요일을 계산합니다.
@@ -79,4 +80,8 @@ export const getSchedule = async (
 	} catch (error) {
 		console.log(error);
 	}
+};
+
+export const getGroupColor = (scheduleId) => {
+	return GROUP_SCHEDULE_COLORS[scheduleId % 20];
 };


### PR DESCRIPTION
# 설명
이슈 내용 + 관련 리팩토링
- #185 
  - 그룹 전환은 상단 그룹 프로필 버튼들 부분 구현하면서 진행하겠습니다. 현재는 초기화까지만입니다. 

- 연관된 코드 리팩토링도 함께 진행하였습니다.
  - dispatch시 담아야 할 payload 생성의 번거로움을 덜고자 전역 state로 이를 받아 thunk 내부적으로 처리하였습니다
  - 서로 다른 컴포넌트에서 진행했던 비동기 작업을 페이지 최상단에 모아두었습니다.  
 
- 구현 중 여러 데이터를 schedule slice의 state로 올려놓았습니다
  -  `currentGroupScheduleId`: 현재 공유 일정에서 보고 있는 그룹의 `id`입니다. `inqueryUserGroup`이 `fulfilled`되고 `userGroupList.length > 0`이면 첫 번째 인덱스에 해당하는 그룹의 groupId로 이 state를 초기화하였습니다.
  - `currentPageType`: **개인 일정**인지 혹은 **공유 일정**인지에 대한 정보입니다. 기존에는 `isGroup` 혹은 `isPersonal`과 같은 prop으로 처리해주었었는데, dispatch할 때마다 이를 받아와 사용해야하는 번거로움이 코드를 지저분하게 만든다고 판단하여 전역으로 올려두었습니다. 이는 개인 일정(혹은 공유 일정) 페이지 첫 렌더링 시 초기화됩니다.